### PR TITLE
comentar id da issue do Jira

### DIFF
--- a/.github/workflows/jira_issue.yml
+++ b/.github/workflows/jira_issue.yml
@@ -33,8 +33,21 @@ jobs:
           summary: ${{ github.event.issue.title }}
           description: ${{ github.event.issue.body }}
 
-
-
+      - name: Comentar o Id da Issue
+        uses: peter-evans/create-or-update-comment@a35cf36e5301d70b76f316e867e7788a55a31dae
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Essa issue foi criada no Jira (backlog). 
+            A tag da issue é: ${{ steps.create.outputs.issue }}
+            **Lembre-se de: ** 
+             - [ ] Colocar a tag ${{ steps.create.outputs.issue }} no inicio do nome da branch
+             - [ ] Colocar a tag ${{ steps.create.outputs.issue }} no inicio da PR
+             - [ ] Linkar essa issue (GitHub) com a PR
+             .
+             Exemplo de nome para branch/PR: ${{ steps.create.outputs.issue }}-${{ github.event.issue.title }}
+      
+      
       - name: Log created issue
         run: echo "Issue ${{ steps.create.outputs.issue }} was created"
 


### PR DESCRIPTION
Sempre que uma issue for criada no GitHub - a action de criar issue deve comentar em cima da issue qual é o id da issue criada no Jira