### PR TITLE
Tm 77 criar cli

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,42 @@
+
+import argparse
+import os
+import sys
+
+# Criar o parser
+from src.config.enums.deployment import REPOSITORIO, KEY
+from src.config.proj_config import ProjConfig
+
+class Cli():
+    parser: argparse.ArgumentParser
+    args: argparse.Namespace
+
+    def __init__(self):
+        myParser = argparse.ArgumentParser(description='Inicializa a execução do mss')
+
+        # Adiciona os argumentos opicionais
+        myParser.add_argument('-repo',
+                               type=str,
+                               help='Especifica o repositório que será utilizado. Default=\'mock\'',
+                               default=ProjConfig.getDeployment()[KEY.TIPO_REPOSITORIO.value])
+
+        myParser.add_argument('-ctrl',
+                               type=str,
+                               help='Especifica o controlador que será utilizado. Default =\'fastapi\'',
+                               default=ProjConfig.getDeployment()[KEY.TIPO_CONTROLADOR.value])
+        self.parser = myParser
+        self.args = myParser.parse_args()
+
+
+    def getArgs(self):
+        return self.args
+
+    def getRepo(self):
+        return self.args.repo
+
+    def getCtrl(self):
+        return self.args.ctrl
+
+
+
+

--- a/src/cli.py
+++ b/src/cli.py
@@ -14,7 +14,7 @@ class Cli():
     def __init__(self):
         myParser = argparse.ArgumentParser(description='Inicializa a execução do mss')
 
-        # Adiciona os argumentos opicionais
+        # Adiciona os argumentos opcionais
         myParser.add_argument('-repo',
                                type=str,
                                help='Especifica o repositório que será utilizado. Default=\'mock\'',

--- a/src/cli.py
+++ b/src/cli.py
@@ -17,13 +17,13 @@ class Cli():
         # Adiciona os argumentos opcionais
         myParser.add_argument('-repo',
                                type=str,
-                               help='Especifica o repositório que será utilizado. Default=\'mock\'',
-                               default=ProjConfig.getDeployment()[KEY.TIPO_REPOSITORIO.value])
+                               default=ProjConfig.getDeployment()[KEY.TIPO_REPOSITORIO.value],
+                               help='Especifica o repositório que será utilizado. Default=%(default)s')
 
         myParser.add_argument('-ctrl',
                                type=str,
-                               help='Especifica o controlador que será utilizado. Default =\'fastapi\'',
-                               default=ProjConfig.getDeployment()[KEY.TIPO_CONTROLADOR.value])
+                               default=ProjConfig.getDeployment()[KEY.TIPO_CONTROLADOR.value],
+                               help='Especifica o repositório que será utilizado. Default=%(default)s')
         self.parser = myParser
         self.args = myParser.parse_args()
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -24,6 +24,12 @@ class Cli():
                                type=str,
                                default=ProjConfig.getDeployment()[KEY.TIPO_CONTROLADOR.value],
                                help='Especifica o repositório que será utilizado. Default=%(default)s')
+
+        myParser.add_argument('-porta',
+                              type=int,
+                              default=ProjConfig.getFastapi()['porta'],
+                              help='Especifica a porta que será utilizada. Default=%(default)s')
+
         self.parser = myParser
         self.args = myParser.parse_args()
 
@@ -36,6 +42,9 @@ class Cli():
 
     def getCtrl(self):
         return self.args.ctrl
+
+    def getPorta(self):
+        return self.args.porta
 
 
 

--- a/src/controladores/fastapi/start.py
+++ b/src/controladores/fastapi/start.py
@@ -1,0 +1,7 @@
+import uvicorn
+
+
+class Start():
+
+    def __call__(self, app, host, porta):
+        uvicorn.run(app=app, host=host, port=porta)

--- a/src/fabricas/controladores/fastapi/fabrica_controlador_fastapi.py
+++ b/src/fabricas/controladores/fastapi/fabrica_controlador_fastapi.py
@@ -4,6 +4,7 @@ from src.config.proj_config import ProjConfig
 from src.config.enums.fastapi import *
 from src.controladores.fastapi.c_fastapi_1 import CFastapi1
 from src.controladores.fastapi.c_fastapi_2 import CFastapi2
+from src.controladores.fastapi.start import Start
 from src.interfaces.IRepo import IRepo
 
 
@@ -38,3 +39,6 @@ class FabricaControladorFastapi:
 
     def metodoControlador2(self, arg: object) -> object:
         return CFastapi2(self.repo)(arg)
+
+    def start(self):
+        return Start()

--- a/src/init.py
+++ b/src/init.py
@@ -8,8 +8,8 @@ from src.fabricas.controladores.fastapi.fabrica_controlador_fastapi import Fabri
 class Init:
     def __call__(
             self,
-            tipo_repo: REPOSITORIO = ProjConfig.getDeployment()[KEY.TIPO_REPOSITORIO.value],
-            tipo_ctrl: CONTROLADOR = ProjConfig.getDeployment()[KEY.TIPO_CONTROLADOR.value]
+            tipo_repo: str = ProjConfig.getDeployment()[KEY.TIPO_REPOSITORIO.value],
+            tipo_ctrl: str = ProjConfig.getDeployment()[KEY.TIPO_CONTROLADOR.value]
     ):
         # Instanciando tipo de REPOSITORIO
         if tipo_repo == REPOSITORIO.MOCK.value:

--- a/src/main.py
+++ b/src/main.py
@@ -1,13 +1,14 @@
 import uvicorn
 
+from src.cli import Cli
 from src.config.proj_config import ProjConfig
 from src.controladores.fastapi.http.requisicoes import *
 from src.controladores.fastapi.http.respostas import *
 from src.init import Init
 
 
-def main():
-    (_, _ctrl) = Init()()
+def main(repo:str, ctrl:str):
+    (_, _ctrl) = Init()(tipo_repo=repo,tipo_ctrl=ctrl)
 
     @_ctrl.app.get('/', response_model=ResRoot)
     async def root():
@@ -31,5 +32,6 @@ def main():
 
 
 if __name__ == '__main__':
-    (_, ctrl) = main()
+    cli = Cli()
+    (_, ctrl) = main(repo=cli.getRepo(), ctrl=cli.getCtrl())
     uvicorn.run(ctrl.app, host=ctrl.host, port=ctrl.porta)

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,6 @@ from src.cli import Cli
 from src.config.proj_config import ProjConfig
 from src.controladores.fastapi.http.requisicoes import *
 from src.controladores.fastapi.http.respostas import *
-from src.controladores.fastapi.start import Start
 from src.init import Init
 
 
@@ -35,5 +34,5 @@ def main(repo:str, ctrl:str):
 if __name__ == '__main__':
     cli = Cli()
     (_, ctrl) = main(repo=cli.getRepo(), ctrl=cli.getCtrl())
-    Start()(app=ctrl.app, host=ctrl.host, porta=cli.getPorta())
+    ctrl.start()(app=ctrl.app, host=ctrl.host, porta=cli.getPorta())
 

--- a/src/main.py
+++ b/src/main.py
@@ -7,8 +7,10 @@ from src.controladores.fastapi.http.respostas import *
 from src.init import Init
 
 
-def main(repo:str, ctrl:str):
-    (_, _ctrl) = Init()(tipo_repo=repo,tipo_ctrl=ctrl)
+def main():
+    # Cria a interface de CLI
+    cli = Cli()
+    (_, _ctrl) = Init()(tipo_repo=cli.getRepo(), tipo_ctrl=cli.getCtrl())
 
     @_ctrl.app.get('/', response_model=ResRoot)
     async def root():
@@ -32,6 +34,5 @@ def main(repo:str, ctrl:str):
 
 
 if __name__ == '__main__':
-    cli = Cli()
-    (_, ctrl) = main(repo=cli.getRepo(), ctrl=cli.getCtrl())
+    (_, ctrl) = main()
     uvicorn.run(ctrl.app, host=ctrl.host, port=ctrl.porta)

--- a/src/main.py
+++ b/src/main.py
@@ -7,10 +7,8 @@ from src.controladores.fastapi.http.respostas import *
 from src.init import Init
 
 
-def main():
-    # Cria a interface de CLI
-    cli = Cli()
-    (_, _ctrl) = Init()(tipo_repo=cli.getRepo(), tipo_ctrl=cli.getCtrl())
+def main(repo:str, ctrl:str):
+    (_, _ctrl) = Init()(tipo_repo=repo,tipo_ctrl=ctrl)
 
     @_ctrl.app.get('/', response_model=ResRoot)
     async def root():
@@ -34,5 +32,6 @@ def main():
 
 
 if __name__ == '__main__':
-    (_, ctrl) = main()
+    cli = Cli()
+    (_, ctrl) = main(repo=cli.getRepo(), ctrl=cli.getCtrl())
     uvicorn.run(ctrl.app, host=ctrl.host, port=ctrl.porta)

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@ from src.cli import Cli
 from src.config.proj_config import ProjConfig
 from src.controladores.fastapi.http.requisicoes import *
 from src.controladores.fastapi.http.respostas import *
+from src.controladores.fastapi.start import Start
 from src.init import Init
 
 
@@ -34,4 +35,5 @@ def main(repo:str, ctrl:str):
 if __name__ == '__main__':
     cli = Cli()
     (_, ctrl) = main(repo=cli.getRepo(), ctrl=cli.getCtrl())
-    uvicorn.run(ctrl.app, host=ctrl.host, port=ctrl.porta)
+    Start()(app=ctrl.app, host=ctrl.host, porta=cli.getPorta())
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,10 +2,11 @@ from fastapi.testclient import TestClient
 
 from src.controladores.fastapi.http.respostas import ResRoot
 from src.fabricas.controladores.fastapi.fabrica_controlador_fastapi import *
+from src.config.enums.deployment import KEY
 from src.main import main
 
 
-(_, ctrl) = main()
+(_, ctrl) = main(repo=ProjConfig.getDeployment()[KEY.TIPO_REPOSITORIO.value], ctrl=ProjConfig.getDeployment()[KEY.TIPO_CONTROLADOR.value])
 client = TestClient(ctrl.app)
 
 


### PR DESCRIPTION
Cria uma interface de linha de comando

Como os valores de -repo e -ctrl tem default, executar py -m src.main terá o mesmo resultado de antes.

Ex de uso:
>py -m src.main -h

Output:

```
usage: main.py [-h] [-repo REPO] [-ctrl CTRL]

Inicializa a execução do mss

optional arguments:
  -h, --help  show this help message and exit
  -repo REPO  Especifica o repositório que será utilizado. Default='mock'
  -ctrl CTRL  Especifica o controlador que será utilizado. Default ='fastapi'
```

Especificar o tipo de repo ou controlador (precisará adicionar esse repo/controlador no Init)

> py -m src.main -repo mysql -ctrl flask

